### PR TITLE
Refactor Card Component: Simplify CSS Classes and Add About Us Section

### DIFF
--- a/astro/src/components/About.astro
+++ b/astro/src/components/About.astro
@@ -1,0 +1,25 @@
+---
+import AboutCard from './AboutCard.astro'
+import { fetchMany, getAbsoluteUrl } from '../lib/strapi';
+const aboutCards = await fetchMany({endpoint: "abouts", query: {populate: "*"}})
+---
+<style is:global>
+.about {
+ width:100%;
+}
+.about>div{
+  display: flex;
+}
+.about div:nth-child(even) {
+ flex-direction: row-reverse;
+}
+</style>
+<h1 class="m-auto w-fit pt-3">ЗА НАС</h1>
+<div class="width-full">
+{
+aboutCards.map((card, index)=>(
+<AboutCard index=`${index + 1}` color=`${card.color}` title=`${card.title}` description=`${card.description}` url=`${getAbsoluteUrl(card.image.url)}`/>
+))
+}
+</div>
+

--- a/astro/src/components/AboutCard.astro
+++ b/astro/src/components/AboutCard.astro
@@ -1,0 +1,25 @@
+---
+const {url, title, description, index, color} = Astro.props
+const shadowDirection = index % 2 ? "8px" : "-8px"
+const secondShadowDirection = index % 2 ? "20px" : "-20px"
+---
+
+<style define:vars={{color, shadowDirection, secondShadowDirection}}>
+.about-card {
+  border: var(--color) solid 5px;
+  box-shadow: var(--shadowDirection) 8px white,
+  var(--secondShadowDirection) 20px var(--color)
+  ;
+}
+
+</style>
+  <div class="width-full items-center flex flex-col md:flex-row max-w-5xl m-auto my-10 p-6 md:even:flex-row-reverse">
+
+  <img class="about-card w-2/3 rounded-2xl overflow-hidden" src={url}/>
+  <h1 style=`color: ${color}` class="mr-10 ml-12 pt-4">#{index}</h1>
+  <div class="w-1/2" >
+    <h1>{title}</h1>
+    <p>{description}</p>
+  </div>
+</div>
+

--- a/astro/src/components/Card.astro
+++ b/astro/src/components/Card.astro
@@ -1,12 +1,10 @@
 ---
 const {
   img,
-  url,
   title,
   footer
 } = Astro.props
 
-let hash = Math.floor(Math.random() * 1000)
 let date = footer.match(/\d+\.\d+\.\d+/)[0]
 ---
 <style>
@@ -15,22 +13,13 @@ let date = footer.match(/\d+\.\d+\.\d+/)[0]
   border: solid white 12px;
 }
 
+
 </style>
-<div class="rounded-2xl bg-white overflow-hidden card">
+<div class="rounded-2xl m-auto mb-16 p-2 bg-white overflow-hidden card w-full md:w-[30%]">
   <img class="rounded-t-2xl w-fll h-72" src={img}/>
   <div class="pt-4 pr-5 pl-5 h-full flex flex-col mb-2">
     <p class="text-gray-500 text-xs mb-2">{date}</p>
-    <p id=`description-${hash}` class="font-bold text-sm mb-9/10"><slot/></p>
+    <p class="text-ellipsis  whitespace-nowrap overflow-hidden  font-bold text-sm mb-9/10"><slot/></p>
   </div>
     <button class="w-2/3 mx-4 mt-auto font-bold bg-blue-500 pt-3 pr-5 text-white text-lg rounded-2xl">Прочитај повеќе</button>
 </div>
-
-<script define:vars={{hash}}>
-  const maxDesciptionLength = 110;
-  let descriptionElement = document.getElementById(`description-${hash}`)
-  let descriptionText = descriptionElement.innerText;
-  if(descriptionText.length > maxDesciptionLength) {
-   descriptionElement.innerText = descriptionText.substring(0, maxDesciptionLength) + "..."
-  }
-</script>
-

--- a/astro/src/components/News.astro
+++ b/astro/src/components/News.astro
@@ -1,0 +1,14 @@
+---
+import { fetchMany, getAbsoluteUrl } from '../lib/strapi';
+import Card from './Card.astro'
+const posts = await fetchMany({endpoint: "posts", query: {populate: "*"}})
+---
+<h1 class="m-auto w-fit">ВЕСТИ</h1>
+<div class="flex flex-col md:flex-row m-auto max-w-5xl justify-between w-1/1">
+{
+posts.map(post=>(
+<Card title=`${post.title}` img=`${getAbsoluteUrl(post.featuredImage?.url)}` footer={`Автор: ${post?.author?.username} | ${post.createdAt.toLocaleString('mk-MK')}`}>{post?.description}</Card>
+))
+}
+</div>
+

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -6,6 +6,8 @@ import Counter from '../components/Counter.astro'
 import ContentMedia from '../components/ContentMedia.astro'
 import Testimonial from '../components/Testimonial.astro'
 import ana from '../assets/img/ana.svg'
+import About from '../components/About.astro'
+import News from '../components/News.astro'
 ---
 
 <DefaultLayout title="Home">
@@ -20,7 +22,8 @@ import ana from '../assets/img/ana.svg'
     <Testimonial testimonial="Одлични наставници со голема емпатија и волја за предавање, кои успеваат да го направат развојот на децата побрз." author="Марија Ангелеска" image={ana} color="orange"/>
   </div>
 </section>
-
+  <About />
+  <News />
 
   <section class="my-64">
     <div class="container">


### PR DESCRIPTION
removed as much as I can css classes, removed logic to trim text in card description instead use css elipse, addded the about us section

![image](https://github.com/user-attachments/assets/fdd814be-d47c-458e-8436-5b8c374fb38f)
This is how the backend for the data that the About component fetches look like